### PR TITLE
pkg: merge ordered subcallstacks

### DIFF
--- a/pkg/stack.go
+++ b/pkg/stack.go
@@ -160,6 +160,7 @@ func loadFileStacks(opts CallstackOptions, files <-chan string, results chan<- [
 }
 
 // LoadCallstacks retrieves the unique set of callstacks across all profiles.
+//
 func LoadCallstacks(files []string, opts ...CallstackOption) (callstacks []Callstack, err error) {
 	var (
 		cOpts   = CallstackOptions{}
@@ -207,6 +208,7 @@ wait:
 }
 
 // sampleStack captures the callstack of a given sample.
+//
 func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callstack) {
 	var (
 		data      = make([]string, len(sample.Location))
@@ -234,6 +236,7 @@ func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callst
 }
 
 // FromPprof converts a pprof profile to a set of unique stacks.
+//
 func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks []Callstack, err error) {
 	if src == nil {
 		err = errors.Errorf("src profile must no be nil")
@@ -254,6 +257,7 @@ func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks 
 
 // Merge takes two sets of callstacks and produce a final one that has only
 // unique callstacks.
+//
 func Merge(callstacks []Callstack) []Callstack {
 	s := newSet()
 
@@ -263,6 +267,7 @@ func Merge(callstacks []Callstack) []Callstack {
 
 // loadPprofProfile loads a *.pprof profile from disk into an in-memory parsed
 // format.
+//
 func loadPprofProfile(file string) (profile *pprof.Profile, err error) {
 	f, err := os.Open(file)
 	if err != nil {

--- a/pkg/stack.go
+++ b/pkg/stack.go
@@ -21,8 +21,6 @@ type Location struct {
 type Callstack struct {
 	Data      []string
 	Locations []Location
-
-	digest [32]byte
 }
 
 type CallstackOptions struct {
@@ -63,11 +61,11 @@ func NewCallstack(data []string, locations []Location, opt *CallstackOptions) (c
 		}
 	}
 
-	callstack.digest = sha256.Sum256([]byte(
-		strings.Join(callstack.Data, "\n")),
-	)
-
 	return
+}
+
+func (c Callstack) digest() [32]byte {
+	return sha256.Sum256([]byte(strings.Join(c.Data, "\n")))
 }
 
 func isPrefix(prefix, stack []string) bool {
@@ -97,12 +95,13 @@ func newSet() callstackSet {
 
 func (c *callstackSet) add(callstacks ...Callstack) {
 	for _, callstack := range callstacks {
-		_, found := c.kv[callstack.digest]
+		digest := callstack.digest()
+		_, found := c.kv[digest]
 		if found {
 			return
 		}
 
-		c.kv[callstack.digest] = struct{}{}
+		c.kv[digest] = struct{}{}
 		c.stacks = append(c.stacks, callstack)
 	}
 }
@@ -161,7 +160,6 @@ func loadFileStacks(opts CallstackOptions, files <-chan string, results chan<- [
 }
 
 // LoadCallstacks retrieves the unique set of callstacks across all profiles.
-//
 func LoadCallstacks(files []string, opts ...CallstackOption) (callstacks []Callstack, err error) {
 	var (
 		cOpts   = CallstackOptions{}
@@ -209,7 +207,6 @@ wait:
 }
 
 // sampleStack captures the callstack of a given sample.
-//
 func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callstack) {
 	var (
 		data      = make([]string, len(sample.Location))
@@ -237,7 +234,6 @@ func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callst
 }
 
 // FromPprof converts a pprof profile to a set of unique stacks.
-//
 func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks []Callstack, err error) {
 	if src == nil {
 		err = errors.Errorf("src profile must no be nil")
@@ -258,7 +254,6 @@ func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks 
 
 // Merge takes two sets of callstacks and produce a final one that has only
 // unique callstacks.
-//
 func Merge(callstacks []Callstack) []Callstack {
 	s := newSet()
 
@@ -268,7 +263,6 @@ func Merge(callstacks []Callstack) []Callstack {
 
 // loadPprofProfile loads a *.pprof profile from disk into an in-memory parsed
 // format.
-//
 func loadPprofProfile(file string) (profile *pprof.Profile, err error) {
 	f, err := os.Open(file)
 	if err != nil {

--- a/pkg/stack.go
+++ b/pkg/stack.go
@@ -70,37 +70,18 @@ func NewCallstack(data []string, locations []Location, opt *CallstackOptions) (c
 	return
 }
 
-func isEqual(a, b []string) bool {
-	for _, vA := range a {
-		for _, vB := range b {
-			if vA != vB {
-				return false
-			}
+func isPrefix(prefix, stack []string) bool {
+	if len(prefix) > len(stack) {
+		return false
+	}
+
+	for i := range prefix {
+		if prefix[i] != stack[i] {
+			return false
 		}
 	}
 
 	return true
-}
-
-func subCallstackMatch(a, b Callstack) []Callstack {
-	lA, lB := len(a.Data), len(b.Data)
-
-	switch {
-	case lA == lB:
-		if isEqual(a.Data, b.Data) {
-			return []Callstack{a}
-		}
-	case lA < lB:
-		if isEqual(a.Data, b.Data[:lA]) {
-			return []Callstack{b}
-		}
-	case lA > lB:
-		if isEqual(a.Data[:lB], b.Data) {
-			return []Callstack{a}
-		}
-	}
-
-	return []Callstack{a, b}
 }
 
 type callstackSet struct {
@@ -127,13 +108,27 @@ func (c *callstackSet) add(callstacks ...Callstack) {
 }
 
 func MergeSubCallstacks(callstacks []Callstack) (merged []Callstack) {
+	if len(callstacks) < 2 {
+		return callstacks
+	}
+
 	s := newSet()
 
-	for i := 0; i < len(callstacks)-1; i++ {
-		for j := i + 1; j < len(callstacks); j++ {
-			s.add(subCallstackMatch(
-				callstacks[i], callstacks[j],
-			)...)
+	for i, callstack := range callstacks {
+		isSubcallstack := false
+		for j, other := range callstacks {
+			if i == j || len(callstack.Data) >= len(other.Data) {
+				continue
+			}
+
+			if isPrefix(callstack.Data, other.Data) {
+				isSubcallstack = true
+				break
+			}
+		}
+
+		if !isSubcallstack {
+			s.add(callstack)
 		}
 	}
 

--- a/pkg/stack_test.go
+++ b/pkg/stack_test.go
@@ -127,8 +127,8 @@ var _ = Describe("Stack", func() {
 			Context("having non-prefix stacks", func() {
 				BeforeEach(func() {
 					callstacks = []pkg.Callstack{
-						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
-						pkg.NewCallstack([]string{"fn1", "fn3"}, nil, nil),
+						{Data: []string{"fn1", "fn2"}},
+						{Data: []string{"fn1", "fn3"}},
 					}
 				})
 

--- a/pkg/stack_test.go
+++ b/pkg/stack_test.go
@@ -67,11 +67,13 @@ var _ = Describe("Stack", func() {
 
 		Context("with single callstack", func() {
 			BeforeEach(func() {
-				callstacks = []pkg.Callstack{}
+				callstacks = []pkg.Callstack{
+					pkg.NewCallstack([]string{"fn1"}, nil, nil),
+				}
 			})
 
-			It("does nothinig", func() {
-				Expect(merged).To(BeEmpty())
+			It("keeps it", func() {
+				Expect(merged).To(Equal(callstacks))
 			})
 		})
 
@@ -79,14 +81,14 @@ var _ = Describe("Stack", func() {
 			Context("being identical", func() {
 				BeforeEach(func() {
 					callstacks = []pkg.Callstack{
-						{Data: []string{"fn1", "fn2"}},
-						{Data: []string{"fn1", "fn2"}},
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
 					}
 				})
 
 				It("reduces to a single one", func() {
-					Expect(merged).To(ConsistOf(pkg.Callstack{
-						Data: []string{"fn1", "fn2"},
+					Expect(merged).To(Equal([]pkg.Callstack{
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
 					}))
 				})
 			})
@@ -94,15 +96,44 @@ var _ = Describe("Stack", func() {
 			Context("havinig one that is part of another", func() {
 				BeforeEach(func() {
 					callstacks = []pkg.Callstack{
-						{Data: []string{"fn1", "fn2"}},
-						{Data: []string{"fn1"}},
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
+						pkg.NewCallstack([]string{"fn1"}, nil, nil),
 					}
 				})
 
 				It("merges", func() {
-					Expect(merged).To(ConsistOf(pkg.Callstack{
-						Data: []string{"fn1", "fn2"},
+					Expect(merged).To(Equal([]pkg.Callstack{
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
 					}))
+				})
+			})
+
+			Context("having a chain of subcallstacks", func() {
+				BeforeEach(func() {
+					callstacks = []pkg.Callstack{
+						pkg.NewCallstack([]string{"fn1", "fn2", "fn3"}, nil, nil),
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
+						pkg.NewCallstack([]string{"fn1"}, nil, nil),
+					}
+				})
+
+				It("keeps only the longest stack", func() {
+					Expect(merged).To(Equal([]pkg.Callstack{
+						pkg.NewCallstack([]string{"fn1", "fn2", "fn3"}, nil, nil),
+					}))
+				})
+			})
+
+			Context("having non-prefix stacks", func() {
+				BeforeEach(func() {
+					callstacks = []pkg.Callstack{
+						pkg.NewCallstack([]string{"fn1", "fn2"}, nil, nil),
+						pkg.NewCallstack([]string{"fn1", "fn3"}, nil, nil),
+					}
+				})
+
+				It("keeps both stacks", func() {
+					Expect(merged).To(Equal(callstacks))
 				})
 			})
 		})


### PR DESCRIPTION
fixes stack merging when a shorter stack is an ordered prefix of a longer stack

the former pairwise comparison required every frame to equal every other frame, so common stacks with distinct frames were never merged

- compare frames by their positions
- retain only stacks that are not prefixes of a longer stack
- cover singleton, chain, duplicate, and non-prefix inputs

closes #3
