### PR TITLE
pkg: retain uniques after duplicate merges

### DIFF
--- a/pkg/stack.go
+++ b/pkg/stack.go
@@ -160,6 +160,7 @@ func loadFileStacks(opts CallstackOptions, files <-chan string, results chan<- [
 }
 
 // LoadCallstacks retrieves the unique set of callstacks across all profiles.
+//
 func LoadCallstacks(files []string, opts ...CallstackOption) (callstacks []Callstack, err error) {
 	var (
 		cOpts   = CallstackOptions{}
@@ -207,6 +208,7 @@ wait:
 }
 
 // sampleStack captures the callstack of a given sample.
+//
 func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callstack) {
 	var (
 		data      = make([]string, len(sample.Location))
@@ -234,6 +236,7 @@ func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callst
 }
 
 // FromPprof converts a pprof profile to a set of unique stacks.
+//
 func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks []Callstack, err error) {
 	if src == nil {
 		err = errors.Errorf("src profile must no be nil")
@@ -254,6 +257,7 @@ func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks 
 
 // Merge takes two sets of callstacks and produce a final one that has only
 // unique callstacks.
+//
 func Merge(callstacks []Callstack) []Callstack {
 	s := newSet()
 
@@ -263,6 +267,7 @@ func Merge(callstacks []Callstack) []Callstack {
 
 // loadPprofProfile loads a *.pprof profile from disk into an in-memory parsed
 // format.
+//
 func loadPprofProfile(file string) (profile *pprof.Profile, err error) {
 	f, err := os.Open(file)
 	if err != nil {

--- a/pkg/stack.go
+++ b/pkg/stack.go
@@ -98,7 +98,7 @@ func (c *callstackSet) add(callstacks ...Callstack) {
 		digest := callstack.digest()
 		_, found := c.kv[digest]
 		if found {
-			return
+			continue
 		}
 
 		c.kv[digest] = struct{}{}
@@ -160,7 +160,6 @@ func loadFileStacks(opts CallstackOptions, files <-chan string, results chan<- [
 }
 
 // LoadCallstacks retrieves the unique set of callstacks across all profiles.
-//
 func LoadCallstacks(files []string, opts ...CallstackOption) (callstacks []Callstack, err error) {
 	var (
 		cOpts   = CallstackOptions{}
@@ -208,7 +207,6 @@ wait:
 }
 
 // sampleStack captures the callstack of a given sample.
-//
 func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callstack) {
 	var (
 		data      = make([]string, len(sample.Location))
@@ -236,7 +234,6 @@ func sampleStack(sample *pprof.Sample, opts *CallstackOptions) (callstack Callst
 }
 
 // FromPprof converts a pprof profile to a set of unique stacks.
-//
 func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks []Callstack, err error) {
 	if src == nil {
 		err = errors.Errorf("src profile must no be nil")
@@ -257,7 +254,6 @@ func CallstacksFromPprof(src *pprof.Profile, opts CallstackOptions) (callstacks 
 
 // Merge takes two sets of callstacks and produce a final one that has only
 // unique callstacks.
-//
 func Merge(callstacks []Callstack) []Callstack {
 	s := newSet()
 
@@ -267,7 +263,6 @@ func Merge(callstacks []Callstack) []Callstack {
 
 // loadPprofProfile loads a *.pprof profile from disk into an in-memory parsed
 // format.
-//
 func loadPprofProfile(file string) (profile *pprof.Profile, err error) {
 	f, err := os.Open(file)
 	if err != nil {

--- a/pkg/stack_test.go
+++ b/pkg/stack_test.go
@@ -272,6 +272,17 @@ var _ = Describe("Stack", func() {
 					pkg.NewCallstack([]string{"a"}, nil, nil),
 				},
 			}),
+			Entry("duplicate followed by a unique stack", scenario{
+				input: []pkg.Callstack{
+					pkg.NewCallstack([]string{"a"}, nil, nil),
+					pkg.NewCallstack([]string{"a"}, nil, nil),
+					pkg.NewCallstack([]string{"b"}, nil, nil),
+				},
+				expected: []pkg.Callstack{
+					pkg.NewCallstack([]string{"a"}, nil, nil),
+					pkg.NewCallstack([]string{"b"}, nil, nil),
+				},
+			}),
 		)
 	})
 


### PR DESCRIPTION
preserves unique callstacks after a duplicate in bulk merge input

the set insertion loop returned at the first duplicate, which skipped all later stacks

- continue after duplicate callstacks
- cover a duplicate followed by a unique stack

closes #5