### PR TITLE
pkg: return from empty profile loads

### DIFF
--- a/pkg/stack.go
+++ b/pkg/stack.go
@@ -162,6 +162,10 @@ func loadFileStacks(opts CallstackOptions, files <-chan string, results chan<- [
 // LoadCallstacks retrieves the unique set of callstacks across all profiles.
 //
 func LoadCallstacks(files []string, opts ...CallstackOption) (callstacks []Callstack, err error) {
+	if len(files) == 0 {
+		return
+	}
+
 	var (
 		cOpts   = CallstackOptions{}
 		stacksC = make(chan []Callstack)

--- a/pkg/stack_test.go
+++ b/pkg/stack_test.go
@@ -236,6 +236,15 @@ var _ = Describe("Stack", func() {
 
 	})
 
+	Describe("LoadCallstacks", func() {
+		It("returns an empty result without files", func() {
+			callstacks, err := pkg.LoadCallstacks(nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(callstacks).To(BeEmpty())
+		})
+	})
+
 	Describe("Merge", func() {
 
 		type scenario struct{ input, expected []pkg.Callstack }


### PR DESCRIPTION
returns promptly when profile loading receives no files

empty input created no workers and then waited for channel results indefinitely

- return before worker setup for empty inputs
- cover empty profile input

closes #7